### PR TITLE
fixing OutOfBoundsException in issues/1

### DIFF
--- a/minesweeper.pde
+++ b/minesweeper.pde
@@ -14,8 +14,12 @@ void draw() {
 }
 
 void mouseClicked () {
+  if (mouseX < grid.offset.x || mouseY < grid.offset.y)
+    return;
   int x = int((mouseX-grid.offset.x)/grid.cell_size);
   int y = int((mouseY-grid.offset.y)/grid.cell_size);
+  if (x >= grid.n_x || y >= grid.n_y)
+    return;
   if (mouseButton == LEFT) {
     if (!grid.cells.get(x+y*grid.n_x).has_flag 
     && !grid.cells.get(x+y*grid.n_x).is_visible) {


### PR DESCRIPTION
This fix should solve all possible OutOfBounds exceptions I managed to find in https://github.com/stgloorious/minesweeper/issues/1

For the lower bounds, my fix is a very simple approach of first checking if the click event happened before the grid even started and aborting.

For the upper bounds, I check if the calculated x or y value is bigger than the actual field size.